### PR TITLE
Add support for `vs config`

### DIFF
--- a/VisualStudio/CommandFactory.cs
+++ b/VisualStudio/CommandFactory.cs
@@ -16,9 +16,10 @@ namespace VisualStudio
 
             RegisterCommand<InstallCommandDescriptor>("install", x => new InstallCommand(x, installerService));
             RegisterCommand<RunCommandDescriptor>("run", x => new RunCommand(x, whereService));
-            RegisterCommand<WhereCommandDescriptor>("where", () => new WhereCommandDescriptor(whereService), x => new WhereCommand(x, whereService));
+            RegisterCommand("where", () => new WhereCommandDescriptor(whereService), x => new WhereCommand(x, whereService));
             RegisterCommand<UpdateCommandDescriptor>("update", x => new UpdateCommand(x, whereService, installerService));
             RegisterCommand<ModifyCommandDescriptor>("modify", x => new ModifyCommand(x, whereService, installerService));
+            RegisterCommand<ConfigCommandDescriptor>("config", x => new ConfigCommand(x, whereService));
         }
 
         public IEnumerable<string> RegisteredCommands => factories.Keys;

--- a/VisualStudio/ConfigCommand.cs
+++ b/VisualStudio/ConfigCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace VisualStudio
+{
+    class ConfigCommand : Command<ConfigCommandDescriptor>
+    {
+        readonly WhereService whereService;
+
+        public ConfigCommand(ConfigCommandDescriptor descriptor, WhereService whereService) : base(descriptor)
+        {
+            this.whereService = whereService;
+        }
+
+        public override async Task ExecuteAsync(TextWriter output)
+        {
+            var instances = await whereService.GetAllInstancesAsync(Descriptor.Sku, Descriptor.Channel);
+            var instance = new VisualStudioInstanceChooser().Choose(instances, output);
+
+            if (instance != null)
+            {
+                var instanceDir = instance.InstallationVersion.Major + ".0_" + instance.InstanceId;
+                if (Descriptor.Experimental)
+                    instanceDir += "Exp";
+
+                var path = Path.Combine(
+                    Environment.ExpandEnvironmentVariables("%LocalAppData%"),
+                    @"Microsoft\VisualStudio",
+                    instanceDir);
+
+                if (Directory.Exists(path))
+                    Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/VisualStudio/ConfigCommandDescriptor.cs
+++ b/VisualStudio/ConfigCommandDescriptor.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Mono.Options;
+
+namespace VisualStudio
+{
+    class ConfigCommandDescriptor : CommandDescriptor
+    {
+        readonly VisualStudioOptions options = new VisualStudioOptions(channelVerb: "Open", showNickname: false);
+        bool exp;
+
+        public ConfigCommandDescriptor() => OptionSet = new CompositeOptionSet(options, new OptionSet
+            {
+                { "exp", "Use experimental folder instead of regular.", e => exp = e != null },
+            });
+
+        public Channel? Channel => options.Channel;
+
+        public Sku? Sku => options.Sku;
+
+        public bool Experimental => exp;
+    }
+}

--- a/VisualStudio/ModifyCommandDescriptor.cs
+++ b/VisualStudio/ModifyCommandDescriptor.cs
@@ -5,7 +5,7 @@ namespace VisualStudio
 {
     class ModifyCommandDescriptor : CommandDescriptor
     {
-        readonly VisualStudioOptions options = new VisualStudioOptions(showNickname: false);
+        readonly VisualStudioOptions options = new VisualStudioOptions(channelVerb: "Modify", showNickname: false);
         readonly WorkloadOptions addWorkloads = new WorkloadOptions("add", "+");
         readonly WorkloadOptions removeWorkloads = new WorkloadOptions("remove", "-");
 

--- a/VisualStudio/Properties/launchSettings.json
+++ b/VisualStudio/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "VisualStudio": {
       "commandName": "Project",
-      "commandLineArgs": "run"
+      "commandLineArgs": "config -pre -exp"
     }
   }
 }

--- a/VisualStudio/UpdateCommandDescriptor.cs
+++ b/VisualStudio/UpdateCommandDescriptor.cs
@@ -4,7 +4,7 @@ namespace VisualStudio
 {
     class UpdateCommandDescriptor : CommandDescriptor
     {
-        readonly VisualStudioOptions options = new VisualStudioOptions(showNickname: false);
+        readonly VisualStudioOptions options = new VisualStudioOptions(channelVerb: "Update", showNickname: false);
 
         public UpdateCommandDescriptor() => OptionSet = new CompositeOptionSet(options);
 

--- a/VisualStudio/VisualStudioOptions.cs
+++ b/VisualStudio/VisualStudioOptions.cs
@@ -13,14 +13,14 @@ namespace VisualStudio
         string[] channelShortcuts = new[] { "pre", "preview", "int", "internal", "master" };
         string[] skuShortcuts = new[] { "e", "ent", "enterprise", "p", "pro", "professional", "c", "com", "community" };
 
-        public VisualStudioOptions(bool showChannel = true, bool showSku = true, bool showNickname = true)
+        public VisualStudioOptions(string channelVerb = "Install", bool showChannel = true, bool showSku = true, bool showNickname = true)
         {
             if (showChannel)
             {
                 // Channel
-                Add("pre|preview", "Install preview version", _ => Channel = VisualStudio.Channel.Preview);
-                Add("int|internal", "Install internal (aka 'dogfood') version", _ => Channel = VisualStudio.Channel.IntPreview);
-                Add("master", "Install master version", _ => Channel = VisualStudio.Channel.Master, hidden: true);
+                Add("pre|preview", channelVerb + " preview version", _ => Channel = VisualStudio.Channel.Preview);
+                Add("int|internal", channelVerb + " internal (aka 'dogfood') version", _ => Channel = VisualStudio.Channel.IntPreview);
+                Add("master", channelVerb + " master version", _ => Channel = VisualStudio.Channel.Master, hidden: true);
             }
 
             if (showSku)
@@ -32,7 +32,7 @@ namespace VisualStudio
             if (showNickname)
             {
                 // Nickname
-                Add("nick|nickname:", "Optional nickname to assign to the installation", n => Nickname = n);
+                Add("nick|nickname:", "Optional nickname to use", n => Nickname = n);
             }
         }
 


### PR DESCRIPTION
This opens the VS configuration directory under `%LocalAppData%\Microsoft\VisualStudio\[MAJOR.0]_[ID][Exp]`.

Allows passing `-exp` to open the experimental folder instead of the regular instance.

Added option to pass in a verb to use for the channel switch, so that it doesn't read "Install ..." on all
commands using the `VisualStudioOptions`.