### PR TITLE
Add back run as the default command, improve its selector

### DIFF
--- a/VisualStudio/ConfigCommand.cs
+++ b/VisualStudio/ConfigCommand.cs
@@ -17,7 +17,7 @@ namespace VisualStudio
         public override async Task ExecuteAsync(TextWriter output)
         {
             var instances = await whereService.GetAllInstancesAsync(Descriptor.Sku, Descriptor.Channel);
-            var instance = new Chooser().Choose(instances, output);
+            var instance = new Chooser("open").Choose(instances, output);
 
             if (instance != null)
             {

--- a/VisualStudio/Program.cs
+++ b/VisualStudio/Program.cs
@@ -1,44 +1,53 @@
 ﻿using System;
 using System.Linq;
-using System.IO;
 using System.Threading.Tasks;
 using Mono.Options;
-using System.Collections.Generic;
 
 namespace VisualStudio
 {
     class Program
     {
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             var commandFactory = new CommandFactory();
 
-            if (args.Any() && commandFactory.IsCommandRegistered(args[0]))
-            {
-                var commandName = args[0];
+            if (args.Length == 0 || new[] { "?", "-?", "/?", "-h", "/h", "--help", "/help" }.Contains(args[0]))
+                return ShowUsage(commandFactory);
 
-                try
-                {
-                    var command = commandFactory.CreateCommand(commandName, args.Skip(1));
+            // Run is the default command if another one is not specified.
+            if (!commandFactory.IsCommandRegistered(args[0]))
+                args = args.Prepend("run").ToArray();
 
-                    await command.ExecuteAsync(Console.Out);
-                }
-                catch (ShowUsageException ex)
-                {
-                    Console.WriteLine($"Usage: {ThisAssembly.Metadata.AssemblyName} {commandName} [options]");
-                    ex.CommandDescriptor.ShowUsage(Console.Out);
-                }
-                catch (OptionException ex)
-                {
-                    Console.WriteLine(ex.Message);
-                }
-            }
-            else
+            var commandName = args[0];
+            try
             {
-                Console.WriteLine();
-                Console.Write($"Usage: {ThisAssembly.Metadata.AssemblyName} [{string.Join('|', commandFactory.RegisteredCommands)}] [options|-?|-h|--help]");
-                Console.WriteLine();
+                var command = commandFactory.CreateCommand(commandName, args.Skip(1));
+
+                await command.ExecuteAsync(Console.Out);
+                // TODO: other exceptions might provide an exit code?
             }
+            catch (ShowUsageException ex)
+            {
+                Console.WriteLine($"Usage: {ThisAssembly.Metadata.AssemblyName} {commandName} [options]");
+                ex.CommandDescriptor.ShowUsage(Console.Out);
+                return -1;
+            }
+            catch (OptionException ex)
+            {
+                Console.WriteLine(ex.Message);
+                return -1;
+            }
+
+            return 0;
+        }
+
+        static int ShowUsage(CommandFactory commandFactory)
+        {
+            Console.WriteLine();
+            Console.Write($"Usage: {ThisAssembly.Metadata.AssemblyName} [{string.Join('|', commandFactory.RegisteredCommands)}] [options|-?|-h|--help]");
+            Console.WriteLine();
+
+            return 0;
         }
     }
 }

--- a/VisualStudio/RunCommandDescriptor.cs
+++ b/VisualStudio/RunCommandDescriptor.cs
@@ -7,7 +7,7 @@ namespace VisualStudio
 {
     class RunCommandDescriptor : CommandDescriptor
     {
-        readonly VisualStudioOptions options = new VisualStudioOptions(showNickname: false);
+        readonly VisualStudioOptions options = new VisualStudioOptions(showChannel: true, showExp: true, showNickname: false);
         readonly WorkloadOptions workloads = new WorkloadOptions("requires", "--", "-");
 
         public RunCommandDescriptor()
@@ -17,7 +17,6 @@ namespace VisualStudio
                 new OptionSet
                 {
                     { "id:", "Run a specific instance by its ID", i => Id = i },
-                    { "exp", "Run with /rootSuffix Exp.", e => Exp = e != null },
                     { "f|first", "If more than one instance matches the criteria, run the first one sorted by descending build version.", f => First = f != null },
                     { "v|version:", "Run specific (semantic) version, such as 16.4 or 16.5.3.", v => Version = v },
                     { "w|wait", "Wait for the started Visual Studio to exit.", w => Wait = w != null },
@@ -40,7 +39,7 @@ namespace VisualStudio
 
         public string Id { get; private set; }
 
-        public bool Exp { get; private set; }
+        public bool IsExperimental => options.IsExperimental;
 
         public IEnumerable<string> WorkloadsArguments => workloads.Arguments;
 


### PR DESCRIPTION
Add channel and experimental instance selection as part of the reusable
VS options.

Make run the default command, as it was before. We'll still render
usage if `vs -?` is used or if `vs` with no arguments is run too.

Added return value to main function just in case consumers want to determine
if the command run successfully or not.