### PR TITLE
Target .NET Core 2.1 which is more broadly available

### DIFF
--- a/VisualStudio.Tests/VisualStudio.Tests.csproj
+++ b/VisualStudio.Tests/VisualStudio.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VisualStudio/VisualStudio.csproj
+++ b/VisualStudio/VisualStudio.csproj
@@ -4,7 +4,7 @@
     <Description>A global tool for managing Visual Studio installations</Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <AssemblyName>vs</AssemblyName>
     <RootNamespace>VisualStudio</RootNamespace>
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="vswhere" Version="2.8.4" PrivateAssets="all" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="MSBuilder.ThisAssembly.Metadata" Version="0.1.4" PrivateAssets="all" />


### PR DESCRIPTION
We don't really use (yet?) any 3.1-specific feature, so
let's lower the requirements instead.

Fix #36, related to #32