### PR TITLE
⁙ Target .net5 natively too

### DIFF
--- a/src/VisualStudio.Tests/VisualStudio.Tests.csproj
+++ b/src/VisualStudio.Tests/VisualStudio.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -4,7 +4,7 @@
     <Description>A global tool for managing Visual Studio installations</Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <AssemblyName>vs</AssemblyName>
     <RootNamespace>VisualStudio</RootNamespace>


### PR DESCRIPTION
This should allow the tool to run on environments that only have net5 installed.

Fixes #50